### PR TITLE
nonlinear example with inhomogeneous boundary conditions should work now

### DIFF
--- a/src/NumCompressibleFlows.jl
+++ b/src/NumCompressibleFlows.jl
@@ -14,7 +14,7 @@ using DrWatson
 @variables x y z t
 
 include("problem_definitions.jl")
-export TestVelocity, P7VortexVelocity, ZeroVelocity, RigidBodyRotation
+export TestVelocity, P7VortexVelocity, ZeroVelocity, ConstantVelocity, RigidBodyRotation
 export TestDensity, ExponentialDensity, LinearDensity, ExponentialDensityRBR
 export EOSType, IdealGasLaw, PowerLaw
 export GridFamily, Mountain2D, UnitSquare, UnstructuredUnitSquare, UniformUnitSquare
@@ -24,7 +24,7 @@ export prepare_data, filename, run_single
 
 
 include("kernels.jl")
-export stab_kernel!, kernel_continuity!, kernel_upwind!, exact_error!, standard_gravity!, energy_kernel!, eos!, kernel_convection_linearoperator!, kernel_inflow!# these functions  change the input data
+export stab_kernel!, kernel_continuity!, kernel_upwind!, exact_error!, standard_gravity!, energy_kernel!, eos!, kernel_convection_linearoperator!, kernel_inflow!, kernel_outflow! # these functions  change the input data
 
 
 #include("compressible_stokes.jl")

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -43,6 +43,17 @@ function kernel_inflow!(u!,ϱ!)
     end
 end
 
+
+## kernel for (u⋅n ϱ^upw, λ) ON_IFACES in continuity equation
+function kernel_outflow!(u!)
+    uval = zeros(Float64, 2)
+    function closure(result, args, qpinfo)
+        u!(uval, qpinfo)
+        flux = dot(uval, qpinfo.normal)
+        result[1] = args[1] * flux
+    end
+end
+
 ## kernel for exact error calculation
 function exact_error!(u!, ∇u!, ϱ!)
     return function closure(result, u, qpinfo)


### PR DESCRIPTION
- repaired in- and outflow operators, the RigidBodyRotation example should work
- also added ConstantVelocity as another test case for the inhomogeneous boundary data

problems/todos:
- outflow conditions use the exact density, but ideally we should use the discrete one here, but then the mass is not preserved anymore... how to ensure that the mass stays constant in this case?
- I changed sign of the \lambda term (otherwise I got no convergence), please check
